### PR TITLE
adding support for google-protobuf brew installs

### DIFF
--- a/protoc-gen-doc.rb
+++ b/protoc-gen-doc.rb
@@ -9,8 +9,11 @@ class ProtocGenDoc < Formula
   depends_on "qt5"
 
   def install
-    protobuf_prefix = `#{HOMEBREW_PREFIX}/bin/brew --prefix protobuf`.chomp!
-    ENV.prepend "PROTOBUF_PREFIX", protobuf_prefix
+    if not `#{HOMEBREW_PREFIX}/bin/brew ls --versions google-protobuf`.empty?
+      ENV.prepend "PROTOBUF_PREFIX", `#{HOMEBREW_PREFIX}/bin/brew --prefix google-protobuf`.chomp!
+    else
+      ENV.prepend "PROTOBUF_PREFIX", `#{HOMEBREW_PREFIX}/bin/brew --prefix protobuf`.chomp!
+    end
     system "qmake"
     system "make"
     bin.install "protoc-gen-doc"


### PR DESCRIPTION
The brew `PROTOBUF_PREFIX` for google's grpc/[google-protobuf](https://github.com/grpc/homebrew-grpc) homebrew install is different that the [default protobuf](https://github.com/Homebrew/homebrew-core/blob/master/Formula/protobuf.rb) install.

This adds a condition to see if the google formula was used in order to use it's `PROTOBUF_PREFIX`